### PR TITLE
Fully Qualified Base Docker Image (Ubuntu 24:04)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Sui dev environment: CLI, local node, Node.js. Builds native for host arch (arm64/amd64).
 # Ubuntu 24.04 required for Sui binary
-FROM ubuntu:24.04
+FROM docker.io/library/ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## What

Changes

```
FROM ubuntu:24.04
```

To

```
FROM docker.io/library/ubuntu:24.04
```

## Why

Non-Docker container engine such as podman won't assume `docker.io` as the default registry, this change fully qualifies the base image for broad compatible with all container engines.

## Testing

Tested on:

1. Docker on Windows 11
2. Podman on Debian 13
3. Podman on NixOS 25.11