### PR TITLE
Pre-approve `esbuild` and `@swc/core` in PNPM

### DIFF
--- a/dapps/pnpm-workspace.yaml
+++ b/dapps/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - '@swc/core'
+  - esbuild
+


### PR DESCRIPTION
This PR [approves post-install](https://pnpm.io/settings#onlybuiltdependencies) scripts for esbuild and @swc/core that are currently blocked by pnpm 9+.

## What are `@swc/core` and `esbuild`?

Historically, JavaScript tooling (like Babel, Webpack, and Terser) was written in JavaScript. `@swc/core` and `esbuild` are part of the modern wave of "next-generation" build tools distributed as compiled native code.

* **`@swc/core` (Speedy Web Compiler):** This is a super-fast JavaScript/TypeScript compiler written in **Rust**. It is designed to be a drop-in replacement for Babel. Tools like Next.js use SWC under the hood to compile your React code into browser-ready JavaScript incredibly fast.
* **`esbuild`:** This is an extremely fast JavaScript bundler and minifier written in **Go**. It takes your various code files and dependencies, packages them together, and shrinks them down for production. It is often 10x to 100x faster than Webpack or Rollup. Tools like Vite rely heavily on esbuild.

## Why do they need to "build" during installation?

When you run `pnpm install`, packages containing native binaries usually have to run a `postinstall` script.

Because a binary compiled for a Mac won't work on Windows, and a binary compiled for an Intel chip won't work on an Apple Silicon chip, the package needs a setup script to detect your specific operating system and CPU architecture. Once it figures that out, the script either downloads the correct binary for your machine or links to it.

Without this step, the tools physically cannot run on your computer.

### Why do I need to run `pnpm approve-builds`?

This comes down to **supply chain security**.

In the NPM ecosystem, `postinstall` scripts have historically been a massive security vulnerability. If a bad actor publishes a malicious package, they can use a `postinstall` script to quietly run a virus, steal your environment variables (like API keys), or inject malware into your machine the exact moment you type `npm install`.

**To protect you, PNPM (starting in v9) blocks all lifecycle scripts by default.** When PNPM sees that `@swc/core` or `esbuild` are trying to run a setup script, it stops them and throws a warning. Running `pnpm approve-builds` is your way of telling PNPM:

> *"I recognize these packages. I trust the maintainers of SWC and esbuild, and I grant them permission to execute code on my machine to set up their native binaries."*

When you run `pnpm approve-builds`, PNPM automatically adds those specific packages to an allowlist in your `package.json` under the `pnpm.onlyBuiltDependencies` array. From then on, PNPM will safely allow those specific tools to install without asking you again, while continuing to block untrusted scripts from any new packages you add.